### PR TITLE
feat(logging): expand wandb config and log full parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,24 +759,28 @@ def on_epoch_end(trainer, epoch, metrics):
 Multiple logging backends with unified interface:
 
 ```python
-from model_training_framework.trainer import (
-    WandBLogger, TensorBoardLogger, ConsoleLogger, CompositeLogger
+from model_training_framework.trainer.config import LoggingConfig, GenericTrainerConfig
+
+# Single logger (W&B)
+cfg = GenericTrainerConfig(
+    logging=LoggingConfig(
+        logger_type="wandb",
+        wandb_project="my_project",
+        wandb_entity="my_team",
+        log_scalars_every_n_steps=10,
+        log_loader_proportions=True,
+    )
 )
 
-# Single logger
-logger = TensorBoardLogger(log_dir="./tb_logs")
-
-# Multiple loggers
-loggers = CompositeLogger([
-    ConsoleLogger(log_level="INFO"),
-    TensorBoardLogger(log_dir="./tb_logs"),
-    WandBLogger(project="my_project", entity="my_team")
-])
-
-config = GenericTrainerConfig(
+# Multiple loggers (console + tensorboard + wandb)
+cfg = GenericTrainerConfig(
     logging=LoggingConfig(
-        logger=loggers,
-        log_every_n_steps=10,
+        logger_type="composite",
+        composite_loggers=["console", "tensorboard", "wandb"],
+        wandb_project="my_project",
+        wandb_entity="my_team",
+        tensorboard_dir="./tb_logs",
+        log_scalars_every_n_steps=10,
         log_loader_proportions=True,
     )
 )

--- a/docs/API.md
+++ b/docs/API.md
@@ -698,11 +698,11 @@ slurm:
   additional_args: []
 
 logging:
-  log_level: "INFO"
   use_wandb: true
   wandb_project: "my_project"
   wandb_entity: "my_team"
-  log_every_n_steps: 10
+  log_scalars_every_n_steps: 10
+  log_images_every_n_steps: 500
 
 checkpoint:
   save_every_n_epochs: 5

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -120,6 +120,10 @@ logging:
   wandb_project: "my_project"
   wandb_entity: "my_team"
   wandb_tags: ["experiment", "baseline"]
+  wandb_name: "experiment-1"
+  wandb_mode: "online"
+  wandb_id: "run-123"
+  wandb_resume: "allow"
   log_every_n_steps: 10
   save_code: true
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -113,19 +113,16 @@ slurm:
 
 # Logging configuration
 logging:
-  log_level: "INFO"
-  log_file: "training.log"
-  console_log: true
   use_wandb: true
   wandb_project: "my_project"
   wandb_entity: "my_team"
   wandb_tags: ["experiment", "baseline"]
   wandb_name: "experiment-1"
-  wandb_mode: "online"
-  wandb_id: "run-123"
-  wandb_resume: "allow"
-  log_every_n_steps: 10
-  save_code: true
+  wandb_mode: "online"      # one of: online|offline|disabled
+  wandb_id: "run-123"        # stable unique run id
+  wandb_resume: "allow"      # one of: allow|must|never
+  log_scalars_every_n_steps: 10
+  log_images_every_n_steps: 500
 
 # Checkpoint configuration
 checkpoint:
@@ -422,6 +419,9 @@ data:
 logging:
   wandb_project: "${WANDB_PROJECT}"
   wandb_entity: "${WANDB_ENTITY}"
+  wandb_mode: "${WANDB_MODE}"       # online|offline|disabled
+  wandb_id: "${WANDB_RUN_ID}"
+  wandb_resume: "${WANDB_RESUME}"   # allow|must|never
 
 slurm:
   account: "${SLURM_ACCOUNT}"
@@ -451,11 +451,19 @@ ${BASE_DIR}/${SUB_DIR}
 # In your shell or job script
 export DATA_ROOT="/scratch/datasets"
 export WANDB_PROJECT="my_experiments"
+export WANDB_ENTITY="my_team"
+export WANDB_MODE="online"          # or offline|disabled
+export WANDB_RUN_ID="run-123"
+export WANDB_RESUME="allow"          # or must|never
 export SLURM_ACCOUNT="research_group"
 
 # Or in a .env file (if using python-dotenv)
 DATA_ROOT=/scratch/datasets
 WANDB_PROJECT=my_experiments
+WANDB_ENTITY=my_team
+WANDB_MODE=online
+WANDB_RUN_ID=run-123
+WANDB_RESUME=allow
 SLURM_ACCOUNT=research_group
 ```
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -45,6 +45,15 @@ config = LoggingConfig(
 )
 ```
 
+Field semantics:
+
+- wandb_mode: one of "online", "offline", "disabled". If omitted, honors the WANDB_MODE environment variable.
+- wandb_resume: one of "allow", "must", "never". Use together with wandb_id to continue a previous run.
+- wandb_id: stable unique run ID to resume or de-duplicate runs.
+- wandb_name: human-readable run display name (does not affect resume).
+
+Note: WandB runs are created only on the primary rank when using DDP. If wandb_mode is not set in the config, the WANDB_MODE environment variable (if present) is respected.
+
 ### Composite Logger
 
 The composite logger allows using multiple logging backends simultaneously:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -29,7 +29,11 @@ from model_training_framework.trainer.config import LoggingConfig
 config = LoggingConfig(
     logger_type="wandb",
     wandb_project="my-project",
-    wandb_entity="my-team"
+    wandb_entity="my-team",
+    wandb_name="run-name",
+    wandb_mode="online",
+    wandb_id="abc123",
+    wandb_resume="allow",
 )
 
 # Composite logger with explicit list

--- a/model_training_framework/config/schemas.py
+++ b/model_training_framework/config/schemas.py
@@ -118,6 +118,10 @@ class LoggingConfig:
     wandb_entity: str | None = None
     wandb_tags: list[str] = field(default_factory=list)
     wandb_notes: str | None = None
+    wandb_name: str | None = None
+    wandb_mode: str | None = None
+    wandb_id: str | None = None
+    wandb_resume: str | None = None
     log_scalars_every_n_steps: int | None = 50
     log_images_every_n_steps: int | None = 500
     log_gradients: bool = False

--- a/model_training_framework/trainer/config.py
+++ b/model_training_framework/trainer/config.py
@@ -317,6 +317,21 @@ class LoggingConfig:
     log_model_parameters: bool = False  # Whether to log model parameter statistics
     log_system_metrics: bool = True  # Whether to log system metrics (GPU, memory, etc.)
 
+    def __post_init__(self) -> None:
+        """Validate WandB-related fields for early, actionable errors."""
+        if self.wandb_mode is not None:
+            valid_modes = {"online", "offline", "disabled"}
+            if self.wandb_mode not in valid_modes:
+                raise ValueError(
+                    f"wandb_mode must be one of {valid_modes}, got {self.wandb_mode!r}"
+                )
+        if self.wandb_resume is not None:
+            valid_resume = {"allow", "must", "never"}
+            if self.wandb_resume not in valid_resume:
+                raise ValueError(
+                    f"wandb_resume must be one of {valid_resume}, got {self.wandb_resume!r}"
+                )
+
 
 @dataclass
 class HooksConfig:

--- a/model_training_framework/trainer/config.py
+++ b/model_training_framework/trainer/config.py
@@ -276,6 +276,10 @@ class LoggingConfig:
     wandb_entity: str | None = None  # W&B entity/team name
     wandb_tags: list[str] = field(default_factory=list)  # Tags for W&B experiment
     wandb_notes: str | None = None  # Notes for W&B experiment
+    wandb_name: str | None = None  # Run name for W&B
+    wandb_mode: str | None = None  # W&B mode (online, offline, disabled)
+    wandb_id: str | None = None  # Unique run ID for W&B
+    wandb_resume: str | None = None  # W&B resume strategy
 
     # TensorBoard configuration
     use_tensorboard: bool = False  # Whether to use TensorBoard logging

--- a/model_training_framework/trainer/core.py
+++ b/model_training_framework/trainer/core.py
@@ -12,10 +12,10 @@ This module provides the GenericTrainer class - the main training engine with:
 
 from __future__ import annotations
 
+from dataclasses import asdict
 import logging
 import os
 from pathlib import Path
-from dataclasses import asdict
 import subprocess
 import time
 from typing import TYPE_CHECKING, Any, Protocol, cast

--- a/model_training_framework/trainer/core.py
+++ b/model_training_framework/trainer/core.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from dataclasses import asdict
 import subprocess
 import time
 from typing import TYPE_CHECKING, Any, Protocol, cast
@@ -287,6 +288,11 @@ class GenericTrainer:
                 entity=config.logging.wandb_entity,
                 tags=config.logging.wandb_tags,
                 notes=config.logging.wandb_notes,
+                run_name=config.logging.wandb_name,
+                mode=config.logging.wandb_mode,
+                id=config.logging.wandb_id,
+                resume=config.logging.wandb_resume,
+                config=asdict(config),
                 loggers_list=config.logging.composite_loggers,
             )
 

--- a/model_training_framework/trainer/core.py
+++ b/model_training_framework/trainer/core.py
@@ -13,6 +13,7 @@ This module provides the GenericTrainer class - the main training engine with:
 from __future__ import annotations
 
 from dataclasses import asdict
+from enum import Enum
 import logging
 import os
 from pathlib import Path
@@ -70,6 +71,35 @@ if TYPE_CHECKING:
     # No direct import of ResumeState needed here; runtime-safe alias is used below
 
 logger = logging.getLogger(__name__)
+
+
+def _json_safe(obj: Any) -> Any:
+    """Convert objects to JSON-serializable structures.
+
+    - Enum -> value
+    - Path -> str
+    - dict/list/tuple/set -> recursively converted containers
+    - int/float/str/bool/None -> unchanged
+    - other -> str(obj)
+    """
+    result: Any
+    match obj:
+        case None:
+            result = None
+        case int() | float() | str() | bool():
+            result = obj
+        case Enum():
+            result = obj.value
+        case Path():
+            result = str(obj)
+        case dict():
+            result = {k: _json_safe(v) for k, v in obj.items()}
+        case list() | tuple() | set():
+            result = [_json_safe(v) for v in obj]
+        case _:
+            result = str(obj)
+    return result
+
 
 # Runtime reference to ResumeState for isinstance/attribute access without triggering import cycles
 # Use a module import to avoid assigning to a type alias
@@ -292,7 +322,7 @@ class GenericTrainer:
                 mode=config.logging.wandb_mode,
                 id=config.logging.wandb_id,
                 resume=config.logging.wandb_resume,
-                config=asdict(config),
+                config=_json_safe(asdict(config)),
                 loggers_list=config.logging.composite_loggers,
             )
 


### PR DESCRIPTION
## Summary
- add wandb_name, wandb_mode, wandb_id, and wandb_resume options to LoggingConfig
- forward full trainer config and new options to WandBLogger
- document new WandB settings in configuration and observability guides

## Goal
- Goal: Enable the tool to resume logging on subsequent runs (reuse a stable run ID/path and append logs instead of starting a new run).

## Testing
- `pytest -q`



------
https://chatgpt.com/codex/tasks/task_e_68b10ee02f148328887c607778676a75