### PR TITLE
Auto-Resume From Latest + Pluggable Warm-Start Loader

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -145,7 +145,39 @@ preemption:
   # Optional: POSIX signal used for preemption handling (matches code examples)
   # signal: USR1  # corresponds to signal.SIGUSR1 in Python
 
+## Warm-start configuration
+
+The warm-start configuration enables loading model weights from arbitrary checkpoint formats at the
+beginning of training (weights-only). This is intended for fine-tuning from external checkpoints
+while keeping the framework’s fault‑tolerant resume separate.
+
+Fields:
+
+- `warm_start.loader_class` (string | optional): Dotted import path to a callable or class that
+  implements `__call__(trainer, checkpoint_path) -> WarmStartResult`.
+- `warm_start.strict` (bool | default: true): Default `strict` for the built-in framework
+  checkpoint model‑only loader (used when no custom loader is provided).
+
+Behavior:
+
+1. If `preemption.resume_from_latest_symlink` is true and a latest checkpoint exists, the trainer fully
+   resumes from it (restores epoch/step/optim/sched/AMP/RNG/dataloader state).
+2. Else if `resume_from_checkpoint` is provided and a warm-start loader is registered, the trainer performs
+   a warm-start (weights-only). If the provided path is a framework checkpoint and no loader is registered,
+   a built‑in model‑only warm‑start is used with `warm_start.strict`.
+3. Else the trainer starts from scratch and applies seeding if configured.
+
+YAML example:
+
+```yaml
+warm_start:
+  loader_class: mypackage.loaders.HFLoader
+  strict: false
+```
+
+```yaml
 # Performance configuration
+
 performance:
   dataloader_num_workers: 4
   pin_memory: true
@@ -156,6 +188,7 @@ performance:
   compile_model: false
 
 # Custom parameters (project-specific)
+
 custom_params:
   use_custom_loss: true
   loss_weight: 0.5
@@ -167,6 +200,7 @@ custom_params:
     - "f1_score"
     - "precision"
     - "recall"
+
 ```
 
 ### Minimal Configuration

--- a/model_training_framework/config/__init__.py
+++ b/model_training_framework/config/__init__.py
@@ -47,6 +47,7 @@ from .schemas import (
     ValAggregation,
     ValidationConfig,
     ValidationFrequency,
+    WarmStartConfig,
     # Validation functions
     validate_infinite_loader_constraints,
     validate_trainer_config,
@@ -83,6 +84,7 @@ __all__ = [  # noqa: RUF022
     "TrainingConfig",
     # Trainer configuration schemas
     "CheckpointConfig",
+    "WarmStartConfig",
     "PreemptionConfig",
     "PerformanceConfig",
     "MultiDataLoaderConfig",

--- a/model_training_framework/config/schemas.py
+++ b/model_training_framework/config/schemas.py
@@ -630,6 +630,19 @@ class PreemptionConfig:
 
 
 @dataclass
+class WarmStartConfig:
+    """
+    Configuration for user-provided warm-start loader.
+
+    When provided, `loader_class` should be an import path to a callable or
+    class implementing a `__call__(trainer, checkpoint_path) -> WarmStartResult`.
+    """
+
+    loader_class: str | None = None  # Dotted import path to a callable/loader class
+    strict: bool = True  # Default strictness if loader does not specify
+
+
+@dataclass
 class PerformanceConfig:
     """
     Configuration for performance optimization features.
@@ -680,6 +693,7 @@ class GenericTrainerConfig:
     validation: ValidationConfig = field(default_factory=ValidationConfig)
     fault_tolerance: FaultToleranceConfig = field(default_factory=FaultToleranceConfig)
     ddp: DDPConfig | None = None  # Optional DDP configuration
+    warm_start: WarmStartConfig | None = None  # Optional warm-start configuration
 
     # Per-loader configuration
     loss_weights_per_loader: list[float] | None = None  # Loss weights per dataloader

--- a/model_training_framework/tests/trainer/test_trainer_auto_resume_precedence.py
+++ b/model_training_framework/tests/trainer/test_trainer_auto_resume_precedence.py
@@ -1,0 +1,144 @@
+"""
+Tests for auto-resume precedence and explicit resume behavior in GenericTrainer.fit().
+
+Covers three behaviors:
+1) No resume when no latest and no resume_from_checkpoint provided
+2) Auto-resume from latest checkpoint when available
+3) Explicit resume from user-provided checkpoint when auto-resume is disabled
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader, TensorDataset
+
+from model_training_framework.trainer import GenericTrainer, GenericTrainerConfig
+
+
+class _SimpleModel(nn.Module):
+    def __init__(self, input_size=4, hidden_size=8, output_size=2):
+        super().__init__()
+        self.fc1 = nn.Linear(input_size, hidden_size)
+        self.fc2 = nn.Linear(hidden_size, output_size)
+
+    def forward(self, x):
+        x = torch.relu(self.fc1(x))
+        return self.fc2(x)
+
+
+def _create_loaders(
+    samples_per_loader: int = 4, batch_size: int = 2, num_loaders: int = 2
+):
+    loaders = []
+    input_size = 4
+    output_size = 2
+    for i in range(num_loaders):
+        X = torch.randn(samples_per_loader, input_size) + i * 0.1
+        y = torch.randint(0, output_size, (samples_per_loader,))
+        ds = TensorDataset(X, y)
+        loaders.append(DataLoader(ds, batch_size=batch_size, shuffle=False))
+    return loaders
+
+
+def _make_trainer(tmp_path):
+    config = GenericTrainerConfig()
+    # Minimize noise, focus on training epochs
+    config.log_loss_every_n_steps = None
+    config.validate_every_n_epochs = 10  # Do not run validation in these tests
+    config.checkpoint.root_dir = tmp_path / "experiment"
+    model = _SimpleModel()
+    optimizers = [optim.SGD(model.parameters(), lr=0.01)]
+    return GenericTrainer(config=config, model=model, optimizers=optimizers)
+
+
+def _set_training_step(trainer: GenericTrainer):
+    def training_step(
+        tr: GenericTrainer, batch, batch_idx, dataloader_idx, dataloader_name
+    ):
+        x, y = batch
+        out = tr.model(x)
+        loss = nn.functional.cross_entropy(out, y)
+        return {"loss": loss}
+
+    trainer.set_training_step(training_step)
+
+
+def test_no_resume_starts_from_scratch(tmp_path):
+    trainer = _make_trainer(tmp_path)
+    _set_training_step(trainer)
+    loaders = _create_loaders(samples_per_loader=4, batch_size=2, num_loaders=2)
+
+    # 2 loaders * (4 samples / 2 batch) = 4 steps per epoch
+    trainer.fit(loaders, max_epochs=1)
+    assert trainer.current_epoch == 1
+    assert trainer.global_step == 4
+
+
+def test_auto_resume_from_latest(tmp_path):
+    # First run: produce a checkpoint at end of epoch 1
+    trainer1 = _make_trainer(tmp_path)
+    _set_training_step(trainer1)
+    loaders = _create_loaders(samples_per_loader=4, batch_size=2, num_loaders=2)
+    trainer1.fit(loaders, max_epochs=1)
+
+    latest = trainer1.checkpoint_manager.get_latest_checkpoint()
+    assert latest is not None
+
+    # Second run: same root_dir; auto-resume from latest and continue to epoch 2
+    trainer2 = _make_trainer(tmp_path)
+    _set_training_step(trainer2)
+    trainer2.fit(loaders, max_epochs=2)
+
+    # After resume, current_epoch should advance to 2;
+    # resume metrics indicate full resume path executed
+    assert trainer2.current_epoch == 2
+    assert trainer2.resume_time_sec is not None
+    assert (trainer2.resume_checkpoint_size_mb or 0) > 0
+
+
+def test_explicit_resume_from_user_checkpoint(tmp_path):
+    # First run: produce a checkpoint at end of epoch 1
+    trainer1 = _make_trainer(tmp_path)
+    _set_training_step(trainer1)
+    loaders = _create_loaders(samples_per_loader=4, batch_size=2, num_loaders=2)
+    trainer1.fit(loaders, max_epochs=1)
+    latest = trainer1.checkpoint_manager.get_latest_checkpoint()
+    assert latest is not None
+
+    # Disable auto-resume and explicitly provide checkpoint path
+    trainer2 = _make_trainer(tmp_path)
+    trainer2.config.preemption.resume_from_latest_symlink = False
+    _set_training_step(trainer2)
+
+    trainer2.fit(loaders, max_epochs=2, resume_from_checkpoint=str(latest))
+
+    assert trainer2.current_epoch == 2
+    assert trainer2.resume_time_sec is not None
+    assert (trainer2.resume_checkpoint_size_mb or 0) > 0
+
+
+def test_skip_auto_resume_when_preloaded(tmp_path):
+    # Seed manager latest by running one full epoch
+    trainer1 = _make_trainer(tmp_path)
+    _set_training_step(trainer1)
+    loaders = _create_loaders(samples_per_loader=4, batch_size=2, num_loaders=2)
+    trainer1.fit(loaders, max_epochs=1)
+    latest = trainer1.checkpoint_manager.get_latest_checkpoint()
+    assert latest is not None
+
+    # New trainer: manually preload the checkpoint before fit
+    trainer2 = _make_trainer(tmp_path)
+    _set_training_step(trainer2)
+
+    from model_training_framework.trainer.checkpoints import (
+        load_checkpoint as free_load,
+    )
+
+    free_load(path=latest, trainer=trainer2)
+
+    # With preloaded logic, auto-resume should be skipped and resume_time_sec stays None
+    trainer2.fit(loaders, max_epochs=2)
+
+    assert trainer2.current_epoch == 2
+    assert trainer2.resume_time_sec is None

--- a/model_training_framework/trainer/checkpoints.py
+++ b/model_training_framework/trainer/checkpoints.py
@@ -553,6 +553,28 @@ class CheckpointManager:
         )
         return CheckpointPayload.from_dict(raw)
 
+    def is_framework_checkpoint(self, path: str | Path) -> bool:
+        """Detect whether a file is a framework checkpoint (format v1).
+
+        Returns True if the file can be loaded and contains required keys
+        like 'format_version' and 'model_state_dict'. Returns False for
+        corrupted files or unknown formats.
+        """
+        try:
+            p = Path(path)
+            if not p.exists() or not p.is_file():
+                return False
+            raw = cast(
+                "dict[str, Any]", torch.load(p, map_location="cpu", weights_only=False)
+            )
+            return (
+                isinstance(raw, dict)
+                and "format_version" in raw
+                and "model_state_dict" in raw
+            )
+        except Exception:
+            return False
+
     def restore_from_checkpoint(
         self,
         model: torch.nn.Module,

--- a/model_training_framework/trainer/core.py
+++ b/model_training_framework/trainer/core.py
@@ -1701,11 +1701,8 @@ class GenericTrainer:
                     )
                     model_state_dict = payload.model_state_dict
                     # If config provides a default strict flag, use it; default True
-                    strict = bool(
-                        getattr(
-                            getattr(self.config, "warm_start", None), "strict", True
-                        )
-                    )
+                    ws_config = self.config.warm_start
+                    strict = ws_config.strict if ws_config is not None else True
 
                 broadcast_data = {
                     "model_state_dict": model_state_dict,

--- a/model_training_framework/trainer/core.py
+++ b/model_training_framework/trainer/core.py
@@ -12,8 +12,9 @@ This module provides the GenericTrainer class - the main training engine with:
 
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from enum import Enum
+import importlib
 import logging
 import os
 from pathlib import Path
@@ -137,6 +138,22 @@ class TrainingStep(Protocol):
             Dictionary with at least 'loss' key
         """
         ...
+
+
+@dataclass
+class WarmStartResult:
+    """Result returned by a warm-start loader."""
+
+    model_state_dict: dict[str, Any]
+    strict: bool = True
+
+
+class WarmStartLoader(Protocol):
+    """Protocol for user-provided warm-start loader."""
+
+    def __call__(
+        self, trainer: GenericTrainer, checkpoint_path: str
+    ) -> WarmStartResult: ...
 
 
 class ValidationStep(Protocol):
@@ -271,6 +288,11 @@ class GenericTrainer:
         self.signal_handler = SignalHandler()
         self.performance_monitor = PerformanceMonitor()
 
+        # Optional warm-start loader and resume metrics
+        self._warm_start_loader: WarmStartLoader | None = None
+        self.resume_time_sec: float | None = None
+        self.resume_checkpoint_size_mb: float | None = None
+
         # Training state
         self.resume_state = create_initial_resume_state(config.checkpoint.save_rng)
         self.global_step = 0
@@ -376,6 +398,22 @@ class GenericTrainer:
 
         logger.info(f"Initialized GenericTrainer with {len(optimizers)} optimizer(s)")
 
+        # Configure warm-start loader from config if provided
+        try:
+            ws_cfg = getattr(config, "warm_start", None)
+            if ws_cfg and getattr(ws_cfg, "loader_class", None):
+                module_path, attr_name = ws_cfg.loader_class.rsplit(".", 1)
+                module = importlib.import_module(module_path)
+                obj = getattr(module, attr_name)
+                # If it's a class, instantiate it; otherwise expect a callable
+                if isinstance(obj, type):
+                    self._warm_start_loader = obj()  # type: ignore[assignment]
+                else:
+                    self._warm_start_loader = obj  # type: ignore[assignment]
+                # If the loader is a class instance or function, we just store it as callable
+        except Exception:
+            logger.exception("Failed to load warm-start loader from config")
+
     def _maybe_requeue_job(self) -> None:
         """Request Slurm to requeue the current job after preemption.
 
@@ -408,6 +446,10 @@ class GenericTrainer:
     def set_validation_step(self, validation_step_fn: ValidationStep) -> None:
         """Set the validation step function with multi-dataloader signature."""
         self.validation_step_fn = validation_step_fn
+
+    def set_warm_start_loader(self, loader: WarmStartLoader) -> None:
+        """Register a user-provided warm-start loader callable."""
+        self._warm_start_loader = loader
 
     def fit(
         self,
@@ -504,13 +546,69 @@ class GenericTrainer:
                     f"{len(self.optimizers)} optimizer(s) provided"
                 )
 
-        # Resume from checkpoint if specified
+        # Determine resume/warm-start behavior
         resumed = False
-        if resume_from_checkpoint:
-            self._resume_from_checkpoint(resume_from_checkpoint)
+
+        # Auto-resume from latest if configured
+        if self.config.preemption.resume_from_latest_symlink:
+            # Skip auto-resume if a checkpoint was already loaded manually
+            preloaded = False
+            try:
+                rs = getattr(self, "resume_state", None)
+                preloaded = (
+                    (self.global_step > 0)
+                    or (self.current_epoch > 0)
+                    or (
+                        rs is not None
+                        and getattr(cast("Any", rs), "dataloader_manager_state", None)
+                        is not None
+                    )
+                )
+            except Exception:
+                preloaded = (self.global_step > 0) or (self.current_epoch > 0)
+            if preloaded:
+                logger.info("Checkpoint already loaded; skipping auto-resume")
+            else:
+                latest = self.checkpoint_manager.get_latest_checkpoint()
+                if latest is not None:
+                    # Avoid resuming from stale checkpoints that already exceed this run's max_epochs
+                    try:
+                        payload = self.checkpoint_manager.load_checkpoint(
+                            str(latest), map_location="cpu"
+                        )
+                        if payload.epoch >= max_epochs:
+                            logger.info(
+                                "Found latest checkpoint but its epoch >= max_epochs; starting fresh"
+                            )
+                        else:
+                            if resume_from_checkpoint:
+                                logger.info(
+                                    "Auto-resuming from latest checkpoint; ignoring resume_from_checkpoint"
+                                )
+                            self._resume_from_checkpoint(str(latest))
+                            resumed = True
+                    except Exception:
+                        logger.exception(
+                            f"Failed pre-check of latest checkpoint {latest}; starting fresh"
+                        )
+                # No latest checkpoint; consider warm-start if provided
+                elif resume_from_checkpoint:
+                    self._warm_start_from_checkpoint(str(resume_from_checkpoint))
+        # Backward-compatible explicit resume behavior
+        elif resume_from_checkpoint:
+            # Special value: 'latest' resolves latest or errors clearly
+            if str(resume_from_checkpoint).lower() == "latest":
+                latest = self.checkpoint_manager.get_latest_checkpoint()
+                if latest is None:
+                    raise FileNotFoundError(
+                        "resume_from_checkpoint='latest' but no checkpoints found"
+                    )
+                self._resume_from_checkpoint(str(latest))
+            else:
+                self._resume_from_checkpoint(str(resume_from_checkpoint))
             resumed = True
 
-        # Setup reproducibility if configured and not resuming
+        # Setup reproducibility if configured and not resuming (warm-start counts as fresh start)
         if not resumed:
             seed_value = getattr(self.config, "seed", None)
             if seed_value is not None:
@@ -1399,11 +1497,24 @@ class GenericTrainer:
 
             # Load checkpoint only on rank 0 and broadcast to other ranks
             if ddp_is_primary(self.fabric):
+                # Size + timing
+                try:
+                    size_mb = Path(checkpoint_path).stat().st_size / (1024 * 1024)
+                    self.resume_checkpoint_size_mb = size_mb
+                    logger.info(
+                        f"Resuming from checkpoint: {checkpoint_path} (size: {size_mb:.2f} MB)"
+                    )
+                except Exception:
+                    logger.debug("Could not stat checkpoint file", exc_info=True)
+
+                t0 = time.time()
                 # Load checkpoint data on rank 0
                 # Map to CPU to avoid device-coupled payloads and reduce GPU memory spikes
                 payload = self.checkpoint_manager.load_checkpoint(
                     checkpoint_path, map_location="cpu"
                 )
+                self.resume_time_sec = time.time() - t0
+                logger.info(f"Checkpoint loaded in {self.resume_time_sec:.2f} seconds")
 
                 # Extract necessary data for broadcast
                 optimizer_states = payload.optimizer_state_dicts or []
@@ -1539,6 +1650,112 @@ class GenericTrainer:
         except Exception:
             logger.exception("Failed to resume from checkpoint: ")
             raise
+
+    def _warm_start_from_checkpoint(self, checkpoint_path: str) -> None:
+        """Warm-start model weights from a checkpoint (no training state restore).
+
+        Only rank 0 performs file I/O or calls user-provided loader; results are
+        broadcast to all ranks. Epoch/step/RNG/dataloader states are intentionally
+        not modified.
+        """
+        # Resolve 'latest' alias for convenience
+        if checkpoint_path.lower() == "latest":
+            latest = self.checkpoint_manager.get_latest_checkpoint()
+            if latest is None:
+                raise FileNotFoundError(
+                    "resume_from_checkpoint='latest' but no checkpoints found"
+                )
+            checkpoint_path = str(latest)
+
+        ddp_barrier(self.fabric)
+
+        # Rank 0 loads state dict using user loader or built-in fallback
+        broadcast_data: dict[str, Any] | None
+        if ddp_is_primary(self.fabric):
+            try:
+                loader = self._warm_start_loader
+                model_state_dict: dict[str, Any]
+                strict: bool
+
+                if loader is not None:
+                    logger.info(
+                        f"Warm-starting model from user loader: {checkpoint_path}"
+                    )
+                    result = loader(self, checkpoint_path)
+                    model_state_dict = result.model_state_dict
+                    strict = bool(getattr(result, "strict", True))
+                else:
+                    # Fallback: framework checkpoint model-only warm start
+                    if not self.checkpoint_manager.is_framework_checkpoint(
+                        checkpoint_path
+                    ):
+                        raise ValueError(
+                            "Non-framework checkpoint detected; register a warm-start loader via "
+                            "trainer.set_warm_start_loader() or config.warm_start.loader_class"
+                        )
+                    logger.info(
+                        f"Warm-starting model from framework checkpoint: {checkpoint_path}"
+                    )
+                    payload = self.checkpoint_manager.load_checkpoint(
+                        checkpoint_path, map_location="cpu"
+                    )
+                    model_state_dict = payload.model_state_dict
+                    # If config provides a default strict flag, use it; default True
+                    strict = bool(
+                        getattr(
+                            getattr(self.config, "warm_start", None), "strict", True
+                        )
+                    )
+
+                broadcast_data = {
+                    "model_state_dict": model_state_dict,
+                    "strict": strict,
+                }
+            except Exception:
+                logger.exception(
+                    f"Failed to warm-start from checkpoint: {checkpoint_path} - "
+                )
+                raise
+        else:
+            broadcast_data = None
+
+        # Broadcast and apply
+        broadcast_data = ddp_broadcast_object(self.fabric, broadcast_data, src=0)
+        assert broadcast_data is not None
+        strict = bool(broadcast_data.get("strict", True))
+        missing = unexpected = None
+        try:
+            result = self.model.load_state_dict(
+                broadcast_data["model_state_dict"], strict=strict
+            )
+            # Report mismatches when not strict
+            if (
+                not strict
+                and hasattr(result, "missing_keys")
+                and hasattr(result, "unexpected_keys")
+            ):
+                missing = list(result.missing_keys)
+                unexpected = list(result.unexpected_keys)
+        except Exception:
+            logger.exception("Model load_state_dict failed during warm-start")
+            raise
+
+        if ddp_is_primary(self.fabric):
+            if not strict:
+                m = len(missing or [])
+                u = len(unexpected or [])
+                sample_m = ", ".join((missing or [])[:5])
+                sample_u = ", ".join((unexpected or [])[:5])
+                logger.info(
+                    f"Warm-start loaded with non-strict mapping: missing={m}, unexpected={u}"
+                )
+                if m:
+                    logger.debug(f"Missing keys (sample): {sample_m}")
+                if u:
+                    logger.debug(f"Unexpected keys (sample): {sample_u}")
+            logger.info("Warm-start completed; starting fresh training run")
+
+        ddp_barrier(self.fabric)
 
     def _log_step_metrics(
         self, metrics: dict[str, Any], step: int, prefix: str = ""


### PR DESCRIPTION
This PR implements automatic resume from the latest framework checkpoint and a pluggable warm-start loader for user checkpoints.

Summary
- Auto-resume from latest framework checkpoint when enabled (full state restore)
-  becomes warm-start (weights-only) when no latest is found
- Warm-start uses user-provided loader via  or 
- Built-in fallback accepts framework checkpoints for model-only warm-start
- DDP-safe broadcast patterns reused for both resume and warm-start

Public API
- 
-  protocol +  dataclass
- 

Internals
- Fit() precedence: latest -> warm-start -> scratch
-  for format detection
- Size/time metrics for resume logging

Tests
- Added  covering:
  1) No resume
  2) Auto-resume from latest
  3) Explicit resume when auto-resume disabled
  4) Skip auto-resume when a checkpoint was manually preloaded

Notes
- Preserves backward compatibility when  is disabled
- Clear errors on non-framework checkpoints without a loader

Closes #10