### PR TITLE
Group dot-separated parameters in experiment names

### DIFF
--- a/model_training_framework/config/naming.py
+++ b/model_training_framework/config/naming.py
@@ -98,7 +98,9 @@ class ExperimentNaming:
 
         # Name is too long; truncate at parameter boundaries and append hash for uniqueness
         name_hash = hashlib.sha256(full_name.encode()).hexdigest()[:8]
-        max_prefix_len = ExperimentNaming.MAX_NAME_LENGTH - len(name_hash) - 1  # underscore before hash
+        max_prefix_len = (
+            ExperimentNaming.MAX_NAME_LENGTH - len(name_hash) - 1
+        )  # underscore before hash
 
         prefix = f"{sanitized_base}_"
         if len(prefix) > max_prefix_len:


### PR DESCRIPTION
## Summary
- group dot-separated parameter keys into single bracketed sections
- cap experiment names at 120 characters, truncating at parameter boundaries and appending a hash
- add regression tests for flattened parameter naming and truncation integrity

## Testing
- `pytest model_training_framework/tests/config/test_naming_improvements.py -q`
- `pre-commit run --files model_training_framework/config/naming.py model_training_framework/tests/config/test_naming_improvements.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b64fadf6f8832893f168a09b724e86